### PR TITLE
Missing space in metadata added

### DIFF
--- a/src/components/Paper.js
+++ b/src/components/Paper.js
@@ -139,9 +139,9 @@ const Paper =
                 <p id="in" className={textClassName}>in
                   <span className={textClassName}>
                     <HighlightableText highlightStrings={highlightStrings} value={published_in}/>
-                    <span className="pubyear">
-                      (<HighlightableText highlightStrings={highlightStrings} value={year} />)
-                    </span>
+                  </span>{" "}
+                  <span className="pubyear">
+                    (<HighlightableText highlightStrings={highlightStrings} value={year} />)
                   </span>
                 </p>
 


### PR DESCRIPTION
There was a missing space character in Paper preview between the metadata `published_in` and `year` so I added it.

I also moved the nested `span` tag up into the paragraph.