### PR TITLE
Zoom-in feature: d3 approach

### DIFF
--- a/src/components/Bubble.js
+++ b/src/components/Bubble.js
@@ -86,7 +86,6 @@ class Bubble extends React.Component {
           y: y_,
           r: r_
         });
-        this.props.store.animationLock = false;
       });
   }
 
@@ -128,10 +127,10 @@ class Bubble extends React.Component {
 
     const areaName = (node.area.length > 55) ? node.area.slice(0,55) + "..." : node.area;
     return (
-      <g onMouseEnter={onBubbleMouseEnter.bind(this, store, node)}
+      <g onMouseEnter={this.isAnimated() ? undefined : onBubbleMouseEnter.bind(this, store, node)}
           onMouseLeave={onBubbleMouseLeave.bind(this, store)}
-          onClick={onBubbleClick.bind(this, store, node)}
-          onDoubleClick={onBubbleDoubleClick.bind(this, store, node)}
+          onClick={this.isAnimated() ? undefined : onBubbleClick.bind(this, store, node)}
+          onDoubleClick={this.isAnimated() ? undefined : onBubbleDoubleClick.bind(this, store, node)}
           className="bubble_frame"
       >
         <circle

--- a/src/components/Bubble.js
+++ b/src/components/Bubble.js
@@ -9,81 +9,88 @@ import {onBubbleMouseEnter, onBubbleMouseLeave, onBubbleClick, onBubbleDoubleCli
  * Binds eventlisteners to bubbles
  * @type {<T extends IReactComponent>(clazz: T) => void | IReactComponent | (function({node?: *, store?: *}))}
  */
-const Bubble =
-  observer(
-    ({node, store}) => {
-      // TODO remove all magical numbers and make styling clearer through classes/external definitions
-      /** TODO
-       * Inline styles in the render function should be either
-       * a) extracted and incorporated in the SASS stylesheets (src/stylesheets)
-       * b) extracted to a Javascript Object that belongs specifically to this
-       *    Component. e.g. let infoModalStyles = { div: { margin: "0 0 30px" } }
-       *    which we could use like <div style={infoModalStyles.div}> ... </div>
-       */
-      let circleClassName = null;
-      let circleStyle = {fillOpacity: "0.8"};
-      if (store.bubblesStore.hasSelectedEntities) {
-        circleClassName = (node.selected) ? "zoom_selected" : "zoom_unselected";
-        circleStyle.fillOpacity = (node.selected) ? "1." : "0.1";
-      } else {
-        circleClassName = node.active ? "zoom_selected" : "area";
-        circleStyle.fillOpacity = (node.active || node.selected) ? "1." : "0.8";
-      }
-      const {orig_x, orig_y, orig_r} = node;
-      const {zoomFactor, translationVecX, translationVecY} = store;
+class Bubble extends React.Component {
+  constructor(props) {
+    super(props);
+  }
 
-      const x_ = zoomFactor * orig_x + translationVecX;
-      const y_ = zoomFactor * orig_y + translationVecY;
-      const r_ = zoomFactor * orig_r;
+  getCoordinates() {
+    const { orig_x, orig_y, orig_r } = this.props.node;
+    const { zoomFactor, translationVecX, translationVecY } = this.props.store;
+  
+    const x_ = zoomFactor * orig_x + translationVecX;
+    const y_ = zoomFactor * orig_y + translationVecY;
+    const r_ = zoomFactor * orig_r;
+  
+    return { x_, y_, r_ };
+  };
+    
 
-      const sqrtOfTwo = Math.sqrt(2);
-      let areaTitleStyle = {wordWrap : "break-word", fontSize : "12px", width: 2*r_/sqrtOfTwo, height: 2*r_/sqrtOfTwo};
-      if ((node.active || node.selected) || (store.bubblesStore.hasSelectedEntities && !node.selected)) {
-        areaTitleStyle.display = "none";
-      }
-      
-      let titleFontSize = "16px";
-      if (store.svgWidth <= 650) {
-        titleFontSize = "12px";
-      } else if (store.svgWidth <= 1050) {
-        titleFontSize = "14px";
-      }
+  render() {
+    let node = this.props.node;
+    let store = this.props.store;
 
-      const highlightStrings = store.searchString.split(' ');
-
-      const areaName = (node.area.length > 55) ? node.area.slice(0,55) + "..." : node.area;
-      return (
-        <g onMouseEnter={onBubbleMouseEnter.bind(this, store, node)}
-           onMouseLeave={onBubbleMouseLeave.bind(this, store)}
-           onClick={onBubbleClick.bind(this, store, node)}
-           onDoubleClick={onBubbleDoubleClick.bind(this, store, node)}
-           className="bubble_frame"
-        >
-          <circle
-            className={circleClassName}
-            r={r_}
-            cx={x_}
-            cy={y_}
-            style={circleStyle}
-          />
-          <foreignObject
-            x={x_ - r_/sqrtOfTwo}
-            y={y_ - r_/sqrtOfTwo}
-            width={2*r_/sqrtOfTwo}
-            height={2*r_/sqrtOfTwo}
-            id="area_title_object"
-            className="headstart"
-          >
-            <div className="outerDiv">
-              <div id="area_title" style={areaTitleStyle} className="innerDiv">
-                  <h2 className="highlightable" style={{fontSize: titleFontSize}}>
-                    <HighlightableText highlightStrings={highlightStrings} value={areaName} />
-                    </h2>
-              </div>
-            </div>
-          </foreignObject>
-        </g>
-      );
+    let circleClassName = null;
+    let circleStyle = {fillOpacity: "0.8"};
+    if (store.bubblesStore.hasSelectedEntities) {
+      circleClassName = (node.selected) ? "zoom_selected" : "zoom_unselected";
+      circleStyle.fillOpacity = (node.selected) ? "1." : "0.1";
+    } else {
+      circleClassName = node.active ? "zoom_selected" : "area";
+      circleStyle.fillOpacity = (node.active || node.selected) ? "1." : "0.8";
     }
-  );
-export default Bubble;
+    
+    const { x_, y_, r_ } = this.getCoordinates();
+
+    const sqrtOfTwo = Math.sqrt(2);
+    let areaTitleStyle = {wordWrap : "break-word", fontSize : "12px", width: 2*r_/sqrtOfTwo, height: 2*r_/sqrtOfTwo};
+    if ((node.active || node.selected) || (store.bubblesStore.hasSelectedEntities && !node.selected)) {
+      areaTitleStyle.display = "none";
+    }
+    
+    let titleFontSize = "16px";
+    if (store.svgWidth <= 650) {
+      titleFontSize = "12px";
+    } else if (store.svgWidth <= 1050) {
+      titleFontSize = "14px";
+    }
+
+    const highlightStrings = store.searchString.split(' ');
+
+    const areaName = (node.area.length > 55) ? node.area.slice(0,55) + "..." : node.area;
+    return (
+      <g onMouseEnter={onBubbleMouseEnter.bind(this, store, node)}
+          onMouseLeave={onBubbleMouseLeave.bind(this, store)}
+          onClick={onBubbleClick.bind(this, store, node)}
+          onDoubleClick={onBubbleDoubleClick.bind(this, store, node)}
+          className="bubble_frame"
+      >
+        <circle
+          className={circleClassName}
+          r={r_}
+          cx={x_}
+          cy={y_}
+          style={circleStyle}
+        />
+        <foreignObject
+          x={x_ - r_/sqrtOfTwo}
+          y={y_ - r_/sqrtOfTwo}
+          width={2 * r_ / sqrtOfTwo}
+          height={2 * r_ / sqrtOfTwo}
+          id="area_title_object"
+          className="headstart"
+        >
+          <div className="outerDiv">
+            <div id="area_title" style={areaTitleStyle} className="innerDiv">
+                <h2 className="highlightable" style={{fontSize: titleFontSize}}>
+                  <HighlightableText highlightStrings={highlightStrings} value={areaName} />
+                  </h2>
+            </div>
+          </div>
+        </foreignObject>
+      </g>
+    );
+  }
+}
+
+export default observer(Bubble);

--- a/src/components/Bubble.js
+++ b/src/components/Bubble.js
@@ -33,12 +33,25 @@ class Bubble extends React.Component {
     return { x_, y_, r_ };
   };
 
-  componentDidUpdate(prevProps) {
-    const { zoomFactor, translationVecX, translationVecY } = this.props.store;
-    // TODO optimize
-    if (prevProps.zoomFactor === zoomFactor && prevProps.translationVecX === translationVecX && prevProps.translationVecY === translationVecY) {
+  componentDidUpdate() {
+    const { x_, y_, r_ } = this.getCoordinates();
+    const { x, y, r } = this.state;
+    if (x === x_ && y === y_ && r === r_ ) {
       return;
     }
+    if (this.props.store.animationLock) {
+      this.animate();
+    } else {
+      this.setState({
+        ...this.state,
+        x: x_,
+        y: y_,
+        r: r_
+      });
+    }
+  }
+
+  animate() {
     let el = d3.select(this.circleRef.current);
     const { x_, y_, r_ } = this.getCoordinates();
 
@@ -58,7 +71,7 @@ class Bubble extends React.Component {
         });
         this.props.store.animationLock = false;
       });
-  } 
+  }
 
   render() {
     let node = this.props.node;

--- a/src/components/Bubble.js
+++ b/src/components/Bubble.js
@@ -102,6 +102,11 @@ class Bubble extends React.Component {
       circleClassName = node.active ? "zoom_selected" : "area";
       circleStyle.fillOpacity = (node.active || node.selected) ? "1." : "0.8";
     }
+
+    let areaStyle = {};
+    if ((node.active || store.bubblesStore.hasSelectedEntities) && !node.selected) {
+      areaStyle.cursor = "zoom-in";
+    }
     
     const { x_, y_, r_ } = this.getCoordinates();
     const { x, y, r } = this.state;
@@ -132,6 +137,7 @@ class Bubble extends React.Component {
           onClick={this.isAnimated() ? undefined : onBubbleClick.bind(this, store, node)}
           onDoubleClick={this.isAnimated() ? undefined : onBubbleDoubleClick.bind(this, store, node)}
           className="bubble_frame"
+          style={areaStyle}
       >
         <circle
           ref={this.circleRef}

--- a/src/components/Bubble.js
+++ b/src/components/Bubble.js
@@ -41,7 +41,7 @@ const Bubble =
       if ((node.active || node.selected) || (store.bubblesStore.hasSelectedEntities && !node.selected)) {
         areaTitleStyle.display = "none";
       }
-      const translateString = "translate(" + x_ + " " + y_ + ")";
+      
       let titleFontSize = "16px";
       if (store.svgWidth <= 650) {
         titleFontSize = "12px";
@@ -58,18 +58,17 @@ const Bubble =
            onClick={onBubbleClick.bind(this, store, node)}
            onDoubleClick={onBubbleDoubleClick.bind(this, store, node)}
            className="bubble_frame"
-           transform={translateString}
         >
           <circle
             className={circleClassName}
             r={r_}
-            cx={0}
-            cy={0}
+            cx={x_}
+            cy={y_}
             style={circleStyle}
           />
           <foreignObject
-            x={0 - r_/sqrtOfTwo}
-            y={0 - r_/sqrtOfTwo}
+            x={x_ - r_/sqrtOfTwo}
+            y={y_ - r_/sqrtOfTwo}
             width={2*r_/sqrtOfTwo}
             height={2*r_/sqrtOfTwo}
             id="area_title_object"

--- a/src/components/Bubble.js
+++ b/src/components/Bubble.js
@@ -106,6 +106,8 @@ class Bubble extends React.Component {
     let areaStyle = {};
     if ((node.active || store.bubblesStore.hasSelectedEntities) && !node.selected) {
       areaStyle.cursor = "zoom-in";
+    } else {
+      areaStyle.cursor = "auto";
     }
     
     const { x_, y_, r_ } = this.getCoordinates();
@@ -145,7 +147,7 @@ class Bubble extends React.Component {
           r={r}
           cx={x}
           cy={y}
-          style={circleStyle}
+          style={{...circleStyle, ...areaStyle}}
         />
         <foreignObject
           x={x_ - r_/sqrtOfTwo}

--- a/src/components/Bubble.js
+++ b/src/components/Bubble.js
@@ -35,6 +35,7 @@ class Bubble extends React.Component {
 
   componentDidUpdate(prevProps) {
     const { zoomFactor, translationVecX, translationVecY } = this.props.store;
+    // TODO optimize
     if (prevProps.zoomFactor === zoomFactor && prevProps.translationVecX === translationVecX && prevProps.translationVecY === translationVecY) {
       return;
     }
@@ -48,14 +49,15 @@ class Bubble extends React.Component {
       .attr("cx", x_)
       .attr("cy", y_)
       .attr("r", r_)
-      .on("end", () =>
+      .on("end", () => {
         this.setState({
           ...this.state,
           x: x_,
           y: y_,
           r: r_
-        })
-      );
+        });
+        this.props.store.animationLock = false;
+      });
   } 
 
   render() {

--- a/src/components/Bubble.js
+++ b/src/components/Bubble.js
@@ -50,6 +50,7 @@ class Bubble extends React.Component {
       .attr("r", r_)
       .on("end", () =>
         this.setState({
+          ...this.state,
           x: x_,
           y: y_,
           r: r_

--- a/src/components/Bubble.js
+++ b/src/components/Bubble.js
@@ -13,7 +13,8 @@ import * as d3 from "d3";
 class Bubble extends React.Component {
   constructor(props) {
     super(props);
-    const { x_, y_, r_ } = this.getCoordinates();
+    this.isAnimatedOnMount = this.isAnimated();
+    const { x_, y_, r_ } = this.getCoordinates(this.isAnimatedOnMount);
     this.state = {
       x: x_,
       y: y_,
@@ -22,9 +23,19 @@ class Bubble extends React.Component {
     this.circleRef = React.createRef();
   }
 
-  getCoordinates() {
+  isAnimated() {
+    return this.props.store.animationLock;
+  }
+
+  getCoordinates(prev = false) {
     const { orig_x, orig_y, orig_r } = this.props.node;
-    const { zoomFactor, translationVecX, translationVecY } = this.props.store;
+    let { zoomFactor, translationVecX, translationVecY } = this.props.store;
+    if (prev) {
+      const { prevZoomFactor, prevTranslationVecX, prevTranslationVecY } = this.props.store;
+      zoomFactor = prevZoomFactor;
+      translationVecX = prevTranslationVecX;
+      translationVecY = prevTranslationVecY;
+    }
   
     const x_ = zoomFactor * orig_x + translationVecX;
     const y_ = zoomFactor * orig_y + translationVecY;
@@ -32,6 +43,12 @@ class Bubble extends React.Component {
   
     return { x_, y_, r_ };
   };
+
+  componentDidMount() {
+    if (this.isAnimatedOnMount) {
+      this.animate();
+    }
+  }
 
   componentDidUpdate() {
     const { x_, y_, r_ } = this.getCoordinates();

--- a/src/components/Bubbles.js
+++ b/src/components/Bubbles.js
@@ -17,9 +17,7 @@ const Bubbles =
       const selectedNodes = nodes.selectedEntities;
       return (
         <g>
-          <NodesList store={store} nodes={flagLessNodes}/>
-          <NodesList store={store} nodes={activeNodes}/>
-          <NodesList store={store} nodes={selectedNodes}/>
+          <NodesList store={store} nodes={nodes.entities}/>
         </g>);
       }
 );

--- a/src/components/Bubbles.js
+++ b/src/components/Bubbles.js
@@ -17,7 +17,9 @@ const Bubbles =
       const selectedNodes = nodes.selectedEntities;
       return (
         <g>
-          <NodesList store={store} nodes={nodes.entities}/>
+          <NodesList store={store} nodes={flagLessNodes}/>
+          <NodesList store={store} nodes={activeNodes}/>
+          <NodesList store={store} nodes={selectedNodes}/>
         </g>);
       }
 );

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -66,6 +66,11 @@ const Chart = observer(
     const hoverPapers = !hasHoverEntities ? '' :
       <Papers store={store} papers={hoveredEntity.filter((paper) => hasSubstring(paper, searchString))}/>;
 
+    let areaStyle = {};
+    if (this.props.store.bubblesStore.hasSelectedEntities) {
+      areaStyle.cursor = "zoom-out";
+    }
+
     return (
         <div className="vis-col">
 
@@ -78,6 +83,7 @@ const Chart = observer(
               id="chart-svg"
               onClick={this.props.store.animationLock ? undefined : onSVGClick.bind(this, store)}
               onMouseOver={this.props.store.animationLock ? undefined : onSVGMouseOver.bind(this, store)}
+              style={areaStyle}
             >
               <g id="chart_canvas">
                 <rect width={svgWidth} height={svgHeight}/>

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -76,8 +76,8 @@ const Chart = observer(
               width={svgWidth}
               height={svgHeight}
               id="chart-svg"
-              onClick={onSVGClick.bind(this, store)}
-              onMouseOver={onSVGMouseOver.bind(this, store)}
+              onClick={this.props.store.animationLock ? undefined : onSVGClick.bind(this, store)}
+              onMouseOver={this.props.store.animationLock ? undefined : onSVGMouseOver.bind(this, store)}
             >
               <g id="chart_canvas">
                 <rect width={svgWidth} height={svgHeight}/>

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -81,7 +81,7 @@ const Chart = observer(
             >
               <g id="chart_canvas">
                 <rect width={svgWidth} height={svgHeight}/>
-                {flaglessPapers}
+                {this.props.store.forceSimIsDone && flaglessPapers}
                 <Nodes store={store} nodes={bubblesStore}/>
                 {activePapers}
                 {selectedPapers}

--- a/src/components/Paper.js
+++ b/src/components/Paper.js
@@ -133,8 +133,8 @@ class Paper extends React.Component {
       .ease(d3.easeLinear)
       .attr("x", x_)
       .attr("y", y_)
-      .attr("w", w_)
-      .attr("h", h_)
+      .attr("width", w_)
+      .attr("height", h_)
       .on("end", () =>
         this.setState({
           ...this.state,
@@ -251,7 +251,7 @@ class Paper extends React.Component {
           y={y}
           width={w}
           height={h}
-          style={{"overflow":"hidden"}}
+          style={{overflow: "hidden"}}
         >
           <div className="paper_holder">
             <div className="metadata" style={metadataStyle}>

--- a/src/components/Paper.js
+++ b/src/components/Paper.js
@@ -216,7 +216,11 @@ class Paper extends React.Component {
       readersDivStyle.marginTop = '5px';
       citationsFontSize = '11px';
     } else {
-      if (papersStore.hasSelectedEntities) displayStyle.display = "none";
+      if (papersStore.hasSelectedEntities) {
+        displayStyle.display = "none";
+      } else {
+        displayStyle.cursor = "zoom-in";
+      }
     }
     if (zoomed) {
       textClassName = 'larger';

--- a/src/components/Paper.js
+++ b/src/components/Paper.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { observer } from 'mobx-react';
 import {onPaperMouseEnter, onPaperMouseLeave, onPaperClick} from '../eventhandlers/PaperEvents';
+import * as d3 from "d3";
 
 import HighlightableText from './HighlightableText';
 
@@ -10,155 +11,221 @@ import HighlightableText from './HighlightableText';
  * Also contains math for the actual coordinate of the Paper on the Chart.
  * @type {<T extends IReactComponent>(clazz: T) => void | IReactComponent | (function({store?: *, paper?: *}))}
  */
-const Paper =
-  observer(
-    ({store, paper}) =>{
-      const {
-        zoomFactor,
-        translationVecX,
-        translationVecY,
-        svgWidth,
-        svgHeight,
-        searchString,
-        papersStore
-      } = store;
-      const {
-        orig_x,
-        orig_y,
-        orig_width,
-        orig_height,
-        zoomed,
-        selected,
-        authors : displayAuthors,
-        title,
-        clicked,
-        oa,
-        readers,
-        published_in,
-        year
-      } = paper;
 
-      // Actual coordinates and dimensions for the Paper is calculated from the
-      // orig_ prefixed values
-      // zoomFactor & translationVecX,Y are set by the zoom state
-      let x =  zoomFactor  *  orig_x + translationVecX;
-      let y =  zoomFactor  *  orig_y + translationVecY;
-      let w =  zoomFactor  *  orig_width;
-      let h =  zoomFactor  *  orig_height;
+class Paper extends React.Component {
+  constructor(props) {
+    super(props);
+    const { x_, y_, w_, h_ } = this.getCoordinates();
+    const path_ = this.getPath(x_, y_, w_, h_);
+    const dogear_ = this.getDogEar(x_, y_, w_, h_);
+    this.state = {
+      x: x_,
+      y: y_,
+      w: w_,
+      h: h_,
+      path: path_,
+      dogear: dogear_
+    };
+    this.pathRef = React.createRef();
+    this.dogearRef = React.createRef();
+    this.objRef = React.createRef();
+  }
 
-      // Caculate enlarged paper dimensions so paper stays within svg
-      // when paper is hovered in zoomed-in visualization state
-      // TODO zoomed flag should be renamed hovered
-      while (
-        zoomed &&
-        ((x + w) < svgWidth) &&
-        ((y + h) < svgHeight) &&
-        (w < svgWidth*0.5) &&
-        (h < svgHeight*0.5)) {
-        w += 1;
-        h += 1.33;
-      }
+  getCoordinates() {
+    const { orig_x, orig_y, orig_width, orig_height } = this.props.paper;
+    const { zoomFactor, translationVecX, translationVecY } = this.props.store;
+  
+    // Actual coordinates and dimensions for the Paper is calculated from the
+    // orig_ prefixed values
+    // zoomFactor & translationVecX,Y are set by the zoom state
+    const x_ =  zoomFactor * orig_x + translationVecX;
+    const y_ =  zoomFactor * orig_y + translationVecY;
+    const w_ =  zoomFactor * orig_width;
+    const h_ =  zoomFactor * orig_height;
+  
+    return { x_, y_, w_, h_ };
+  };
 
-      // The messy part
-      // Creates SVG paths
-      // Adds css classes/other styles according to visualization state
-      // TODO extract parts of it to functions, define css classes instead of manually styling them here
-      let textClassName = 'highlightable';
-      const pathD = 'M ' + x + ' ' + y +
-                    ' h ' + (0.9*w) +
-                    ' l ' + (0.1*w) + ' ' + (0.1*h) +
-                    ' v ' + (0.9*h) +
-                    ' h ' + (-w) +
-                    ' v ' + (-h);
-      let pathClassName = clicked ? 'framed' : 'unframed';
-      let openAccessStyle = oa ? {height: (15) + "px", display: "block", marginBottom:"3px"} : {display: "none"};
+  componentDidUpdate(prevProps) {
+    const { zoomFactor, translationVecX, translationVecY } = this.props.store;
+    if (prevProps.zoomFactor === zoomFactor && prevProps.translationVecX === translationVecX && prevProps.translationVecY === translationVecY) {
+      return;
+    }
 
-      let dogearPath = "M " + (x + 0.9*w) + ' ' + y + " v " + (0.1*h) + " h " + (0.1*w);
-      let displayStyle = {display: "block", cursor : "default"};
-      let metadataStyle = {height: (0.75*h) + "px", width: (0.9*w) + "px"};
-      let readersDivStyle = {height: 0.24*h + "px", width: w + "px", marginBottom: "0px", marginTop: "0px"};
-      let citationsFontSize = "8px";
-      let highlightStrings = searchString.split(' ');
+    this.animatePath();
+  }
 
-      if (selected) {
-        textClassName = 'large highlightable';
-        displayStyle.cursor = "pointer";
-        metadataStyle.height = (h - 20) + "px";
-        readersDivStyle.height = 15 + "px";
-        readersDivStyle.marginBottom = '3px';
-        readersDivStyle.marginTop = '5px';
-        citationsFontSize = '11px';
-      } else {
-        if (papersStore.hasSelectedEntities) displayStyle.display = "none";
-      }
-      if (zoomed) {
-        textClassName = 'larger';
-        citationsFontSize = '11px';
-      }
+  animatePath() {
+    const { x_, y_, w_, h_ } = this.getCoordinates();
+    const path = this.getPath(x_, y_, w_, h_);
 
-      return (
-        <g
-          onMouseEnter={onPaperMouseEnter.bind(this, store, paper)}
-          onMouseLeave={onPaperMouseLeave.bind(this, store, paper)}
-          onClick={onPaperClick.bind(this, store, paper)}
-          className="paper"
-          style={displayStyle}
+    let el = d3.select(this.pathRef.current);
+    el.transition()
+      .duration(500)
+      .ease(d3.easeLinear)
+      .attr("d", path)
+      .on("end", () =>
+        this.setState({
+          ...this.state,
+          path: path
+        })
+      );
+  }
+
+  animateDogEar() {
+    const { x_, y_, w_, h_ } = this.getCoordinates();
+    const path = this.getDogEar(x_, y_, w_, h_);
+
+    let el = d3.select(this.dogearRef.current);
+    el.transition()
+      .duration(500)
+      .ease(d3.easeLinear)
+      .attr("d", path)
+      .on("end", () =>
+        this.setState({
+          ...this.state,
+          dogear: path
+        })
+      );
+  }
+
+  getPath(x, y, w, h) {
+    const pathD = 'M ' + x + ' ' + y +
+                  ' h ' + (0.9 * w) +
+                  ' l ' + (0.1 * w) + ' ' + (0.1 * h) +
+                  ' v ' + (0.9 * h) +
+                  ' h ' + (-w) +
+                  ' v ' + (-h);
+
+    return pathD;
+  }
+
+  getDogEar(x, y, w, h) {
+    return "M " + (x + 0.9 * w) + ' ' + y + " v " + (0.1 * h) + " h " + (0.1 * w);
+  }
+
+  render() {
+    const store = this.props.store;
+    const paper = this.props.paper;
+
+    const { x_, y_, w_, h_ } = this.getCoordinates();
+    let { x, y, w, h, path } = this.state;
+    const { svgWidth, svgHeight, searchString, papersStore } = store;
+    const {
+      zoomed,
+      selected,
+      authors : displayAuthors,
+      title,
+      clicked,
+      oa,
+      readers,
+      published_in,
+      year
+    } = paper;
+
+    // Caculate enlarged paper dimensions so paper stays within svg
+    // when paper is hovered in zoomed-in visualization state
+    // TODO zoomed flag should be renamed hovered
+    while (
+      zoomed &&
+      ((x + w) < svgWidth) &&
+      ((y + h) < svgHeight) &&
+      (w < svgWidth*0.5) &&
+      (h < svgHeight*0.5)) {
+      w += 1;
+      h += 1.33;
+    }
+
+    // The messy part
+    // Creates SVG paths
+    // Adds css classes/other styles according to visualization state
+    // TODO extract parts of it to functions, define css classes instead of manually styling them here
+    let textClassName = 'highlightable';
+    let pathClassName = clicked ? 'framed' : 'unframed';
+    let openAccessStyle = oa ? {height: (15) + "px", display: "block", marginBottom:"3px"} : {display: "none"};
+
+    let dogearPath = this.getDogEar(x, y, w, h);
+    let displayStyle = {display: "block", cursor : "default"};
+    let metadataStyle = {height: (0.75*h) + "px", width: (0.9*w) + "px"};
+    let readersDivStyle = {height: 0.24*h + "px", width: w + "px", marginBottom: "0px", marginTop: "0px"};
+    let citationsFontSize = "8px";
+    let highlightStrings = searchString.split(' ');
+
+    if (selected) {
+      textClassName = 'large highlightable';
+      displayStyle.cursor = "pointer";
+      metadataStyle.height = (h - 20) + "px";
+      readersDivStyle.height = 15 + "px";
+      readersDivStyle.marginBottom = '3px';
+      readersDivStyle.marginTop = '5px';
+      citationsFontSize = '11px';
+    } else {
+      if (papersStore.hasSelectedEntities) displayStyle.display = "none";
+    }
+    if (zoomed) {
+      textClassName = 'larger';
+      citationsFontSize = '11px';
+    }
+
+    return (
+      <g
+        onMouseEnter={onPaperMouseEnter.bind(this, store, paper)}
+        onMouseLeave={onPaperMouseLeave.bind(this, store, paper)}
+        onClick={onPaperClick.bind(this, store, paper)}
+        className="paper"
+        style={displayStyle}
+      >
+        <path
+          ref={this.pathRef}
+          id="region"
+          d={path}
+          className={pathClassName}
         >
+        </path>
 
-          <path
-            id="region"
-            d={pathD}
-            className={pathClassName}
-          >
-          </path>
-
-          <path
+        <path
           className="dogear"
           d={dogearPath}>
         </path>
 
-          <foreignObject
-            x={x}
-            y={y}
-            width={w}
-            height={h}
-            style={{"overflow":"hidden"}}
-          >
-            <div className="paper_holder">
-
-              <div className="metadata" style={metadataStyle}>
-                <div id="icons" style={openAccessStyle}>
-                  <p id="open-access-logo" className={textClassName}>&#xf09c;</p>
-                </div>
-                <p id="title" className={textClassName}>
-                  <HighlightableText highlightStrings={highlightStrings} value={title}/>
-                </p>
-                <p id="details" className={textClassName}>
-                  <HighlightableText highlightStrings={highlightStrings} value={displayAuthors}/>
-                </p>
-                <p id="in" className={textClassName}>in
-                  <span className={textClassName}>
-                    <HighlightableText highlightStrings={highlightStrings} value={published_in}/>
-                    <span className="pubyear">
-                      (<HighlightableText highlightStrings={highlightStrings} value={year} />)
-                    </span>
+        <foreignObject
+          x={x}
+          y={y}
+          width={w}
+          height={h}
+          style={{"overflow":"hidden"}}
+        >
+          <div className="paper_holder">
+            <div className="metadata" style={metadataStyle}>
+              <div id="icons" style={openAccessStyle}>
+                <p id="open-access-logo" className={textClassName}>&#xf09c;</p>
+              </div>
+              <p id="title" className={textClassName}>
+                <HighlightableText highlightStrings={highlightStrings} value={title}/>
+              </p>
+              <p id="details" className={textClassName}>
+                <HighlightableText highlightStrings={highlightStrings} value={displayAuthors}/>
+              </p>
+              <p id="in" className={textClassName}>in
+                <span className={textClassName}>
+                  <HighlightableText highlightStrings={highlightStrings} value={published_in}/>
+                  <span className="pubyear">
+                    (<HighlightableText highlightStrings={highlightStrings} value={year} />)
                   </span>
-                </p>
-
-              </div>
-
-              <div className="readers" style={readersDivStyle}>
-                <p id="readers" className={textClassName}>
-                  <span id="num-readers">{readers}</span>
-                  <span className="readers_entity" style={{fontSize: citationsFontSize}}> citations</span>
-                </p>
-              </div>
-
+                </span>
+              </p>
             </div>
-          </foreignObject>
-        </g>
-      )
-    }
-  );
+            <div className="readers" style={readersDivStyle}>
+              <p id="readers" className={textClassName}>
+                <span id="num-readers">{readers}</span>
+                <span className="readers_entity" style={{fontSize: citationsFontSize}}> citations</span>
+              </p>
+            </div>
+          </div>
+        </foreignObject>
+      </g>
+    )
+  }
+}
 
-export default Paper;
+export default observer(Paper);

--- a/src/components/Paper.js
+++ b/src/components/Paper.js
@@ -225,9 +225,9 @@ class Paper extends React.Component {
 
     return (
       <g
-        onMouseEnter={onPaperMouseEnter.bind(this, store, paper)}
+        onMouseEnter={this.isAnimated() ? undefined : onPaperMouseEnter.bind(this, store, paper)}
         onMouseLeave={onPaperMouseLeave.bind(this, store, paper)}
-        onClick={onPaperClick.bind(this, store, paper)}
+        onClick={this.isAnimated() ? undefined : onPaperClick.bind(this, store, paper)}
         className="paper"
         style={displayStyle}
       >

--- a/src/components/Paper.js
+++ b/src/components/Paper.js
@@ -64,7 +64,7 @@ const Paper =
       // Adds css classes/other styles according to visualization state
       // TODO extract parts of it to functions, define css classes instead of manually styling them here
       let textClassName = 'highlightable';
-      const pathD = 'M ' + 0 + ' ' + 0 +
+      const pathD = 'M ' + x + ' ' + y +
                     ' h ' + (0.9*w) +
                     ' l ' + (0.1*w) + ' ' + (0.1*h) +
                     ' v ' + (0.9*h) +
@@ -73,12 +73,11 @@ const Paper =
       let pathClassName = clicked ? 'framed' : 'unframed';
       let openAccessStyle = oa ? {height: (15) + "px", display: "block", marginBottom:"3px"} : {display: "none"};
 
-      let dogearPath = "M " + (0 + 0.9*w) + ' ' + 0 + " v " + (0.1*h) + " h " + (0.1*w);
+      let dogearPath = "M " + (x + 0.9*w) + ' ' + y + " v " + (0.1*h) + " h " + (0.1*w);
       let displayStyle = {display: "block", cursor : "default"};
       let metadataStyle = {height: (0.75*h) + "px", width: (0.9*w) + "px"};
       let readersDivStyle = {height: 0.24*h + "px", width: w + "px", marginBottom: "0px", marginTop: "0px"};
       let citationsFontSize = "8px";
-      let translateString = "translate(" + x + " " + y + ")";
       let highlightStrings = searchString.split(' ');
 
       if (selected) {
@@ -104,7 +103,6 @@ const Paper =
           onClick={onPaperClick.bind(this, store, paper)}
           className="paper"
           style={displayStyle}
-          transform={translateString}
         >
 
           <path
@@ -120,6 +118,8 @@ const Paper =
         </path>
 
           <foreignObject
+            x={x}
+            y={y}
             width={w}
             height={h}
             style={{"overflow":"hidden"}}

--- a/src/components/Paper.js
+++ b/src/components/Paper.js
@@ -66,14 +66,25 @@ class Paper extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps) {
-    const { zoomFactor, translationVecX, translationVecY } = this.props.store;
-    const prevStore = prevProps.store;
-    if (prevStore.zoomFactor === zoomFactor && prevStore.translationVecX === translationVecX && prevStore.translationVecY === translationVecY) {
+  componentDidUpdate() {
+    const { x_, y_, w_, h_ } = this.getCoordinates();
+    const { x, y, w, h } = this.state;
+    
+    if (x === x_ && y === y_ && w === w_ && h === h_ ) {
       return;
     }
 
-    this.animate();
+    if (this.props.store.animationLock) {
+      this.animate();
+    } else {
+      this.setState({
+        ...this.state,
+        x: x_,
+        y: y_,
+        w: w_,
+        h: h_
+      });
+    }
   }
 
   animate() {

--- a/src/models/UIStore.js
+++ b/src/models/UIStore.js
@@ -27,6 +27,7 @@ class UIStore {
     this.previousSVGSize = Math.min(initWidth*0.6, initHeight);
     this.isZoomed = false;
     this.lock = false;
+    this.animationLock = false;
 
     // extendObservable tells MobX that these members of UIStore are observable.
     // When an observable is changed, all observers are updated automatically.
@@ -43,6 +44,9 @@ class UIStore {
       zoomFactor: 1,            // the zoomFactor - a value of 1 means no zoom
       translationVecX: 0,       // a translation vector for the x coordinate, value of 0 means the viz is centered
       translationVecY: 0,       // a translation vector for the y coordinate, value of 0 means the viz is centered
+      prevZoomFactor: 1,
+      prevTranslationVecX: 0,
+      prevTranslationVecY: 0,
       searchString: "",         // the string entered into the list search input
       displayList: true,        // whether list is shown or not
       sortOption: null,         // by which criteria the list should be sorted
@@ -102,22 +106,37 @@ class UIStore {
     const midx = this.svgWidth*0.5;
     const midy = this.svgHeight*0.5;
 
-    // TODO remove ratio?
+    // TODO remove ???
     let ratio = 1.0;
     const easeFactor = easePolyInOut(ratio, 1.2);
-    const newz = (1 - easeFactor)*startz_ + easeFactor*z;
-    const newy = (1 - easeFactor)*starty_ + easeFactor*y;
-    const newx = (1 - easeFactor)*startx_ + easeFactor*x;
+    const newz = (1 - easeFactor) * startz_ + easeFactor * z;
+    const newy = (1 - easeFactor) * starty_ + easeFactor * y;
+    const newx = (1 - easeFactor) * startx_ + easeFactor * x;
 
-    this.translationVecX = midx - newz*newx;
-    this.translationVecY = midy - newz*newy;
-    this.zoomFactor = newz;
+    this.animationLock = true;
+    this.setTranslationVecX(midx - newz * newx);
+    this.setTranslationVecY(midy - newz * newy);
+    this.setZoomFactor(newz);
     // this.updateZoomState2(startz, startx, starty);
     
     // TODO callback not needed if synchronous
     if (typeof  callback === 'function') callback();
   }
 
+  setTranslationVecX(translationVecX) {
+    this.prevTranslationVecX = this.translationVecX;
+    this.translationVecX = translationVecX;
+  }
+
+  setTranslationVecY(translationVecY) {
+    this.prevTranslationVecY = this.translationVecY;
+    this.translationVecY = translationVecY;
+  }
+
+  setZoomFactor(zoomFactor) {
+    this.prevZoomFactor = this.zoomFactor;
+    this.zoomFactor = zoomFactor;
+  }
 
   /**
    * Returns the visualization to the original 'zoomed-out' state;

--- a/src/models/UIStore.js
+++ b/src/models/UIStore.js
@@ -102,7 +102,6 @@ class UIStore {
     const midx = this.svgWidth*0.5;
     const midy = this.svgHeight*0.5;
 
-    const duration = this.config.zoomDuration;
     // TODO remove ratio?
     let ratio = 1.0;
     const easeFactor = easePolyInOut(ratio, 1.2);

--- a/src/models/UIStore.js
+++ b/src/models/UIStore.js
@@ -27,7 +27,6 @@ class UIStore {
     this.previousSVGSize = Math.min(initWidth*0.6, initHeight);
     this.isZoomed = false;
     this.lock = false;
-    this.animationLock = false;
 
     // extendObservable tells MobX that these members of UIStore are observable.
     // When an observable is changed, all observers are updated automatically.
@@ -50,7 +49,8 @@ class UIStore {
       searchString: "",         // the string entered into the list search input
       displayList: true,        // whether list is shown or not
       sortOption: null,         // by which criteria the list should be sorted
-      topic: 'cool'             // the topic of the map, to be included in the subtitle
+      topic: 'cool',            // the topic of the map, to be included in the subtitle
+      animationLock: false
     });
     this.initCoords(this.previousSVGSize);
   }
@@ -117,6 +117,7 @@ class UIStore {
     this.setTranslationVecX(midx - newz * newx);
     this.setTranslationVecY(midy - newz * newy);
     this.setZoomFactor(newz);
+    setTimeout(() => this.animationLock = false, 500);
     // this.updateZoomState2(startz, startx, starty);
     
     // TODO callback not needed if synchronous

--- a/src/models/UIStore.js
+++ b/src/models/UIStore.js
@@ -103,24 +103,20 @@ class UIStore {
     const midy = this.svgHeight*0.5;
 
     const duration = this.config.zoomDuration;
-    let ratio = 0.;
-    let t = timer(elapsed => {
-      ratio = (elapsed/duration) > 1 ? 1. : elapsed/duration;
-      const easeFactor = easePolyInOut(ratio, 1.2);
-      const newz = (1 - easeFactor)*startz_ + easeFactor*z;
-      const newy = (1 - easeFactor)*starty_ + easeFactor*y;
-      const newx = (1 - easeFactor)*startx_ + easeFactor*x;
+    // TODO remove ratio?
+    let ratio = 1.0;
+    const easeFactor = easePolyInOut(ratio, 1.2);
+    const newz = (1 - easeFactor)*startz_ + easeFactor*z;
+    const newy = (1 - easeFactor)*starty_ + easeFactor*y;
+    const newx = (1 - easeFactor)*startx_ + easeFactor*x;
 
-      this.translationVecX = midx - newz*newx;
-      this.translationVecY = midy - newz*newy;
-      this.zoomFactor = newz;
-      // this.updateZoomState2(startz, startx, starty);
-
-      if ( elapsed > duration ) {
-        t.stop();
-        if (typeof  callback === 'function') callback();
-      }
-    });
+    this.translationVecX = midx - newz*newx;
+    this.translationVecY = midy - newz*newy;
+    this.zoomFactor = newz;
+    // this.updateZoomState2(startz, startx, starty);
+    
+    // TODO callback not needed if synchronous
+    if (typeof  callback === 'function') callback();
   }
 
 


### PR DESCRIPTION
I used the `d3` library to animate the zoom-in and zoom-out functionality. 

I tried it on Chrome and Firefox. The performance is better than the previous version and it also behaves more like the current Headstart.

I had to rewrite the `Paper` and `Bubble` components to class components.

For the components that are mounted during the animation run, it was necessary to store the previous zoom values. 

It was also needed to somehow track whether the animation is running or not. That's why I added the `animationLock` property and a timer into the `UIStore`. Next time I'd do it differently though - probably similarly to the current Headstart, where the transitions increment and decrement some counter.

I already know about some bugs:

- There is a warning saying an unmounted component is updated. This can be probably solved by stopping the transition on `componentWillUnmount()`.
- When resizing the window, the papers jump out of the bubbles. I'll try to debug this.
- Not exactly a bug, it's more like a difference to the current Headstart: when the zoom in is running, it's not possible to zoom out.

Some things could have been done better (e.g. the function `updateZoomStateAnimated` could be refactored into much smaller piece of code), but I think that can be done during the final implementation.